### PR TITLE
allow passing args and wayland

### DIFF
--- a/org.pgadmin.pgadmin4.yml
+++ b/org.pgadmin.pgadmin4.yml
@@ -12,6 +12,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
   - --talk-name=org.freedesktop.secrets
@@ -143,7 +144,7 @@ modules:
 
       - type: script
         commands:
-          - zypak-wrapper /app/pgAdmin4/bin/pgadmin4
+          - zypak-wrapper /app/pgAdmin4/bin/pgadmin4 "$@"
         dest-filename: run.sh
 
       - type: file


### PR DESCRIPTION
no need to not make available passing args to zypak-wrapper.

also add --socket=wayland so that the user can invoke with `--enable-features=UseOzonePlatform --ozone-platform=wayland` to allow the app to use wayland.